### PR TITLE
Fixed request_id on progname for logger.

### DIFF
--- a/lib/echo_common/configuration.rb
+++ b/lib/echo_common/configuration.rb
@@ -1,4 +1,5 @@
 require 'echo_common/error'
+require 'echo_common/logger/formatter'
 require 'lotus/logger'
 
 module EchoCommon
@@ -56,10 +57,8 @@ module EchoCommon
     def logger(tag: nil, level: self[:log_level])
       ::Lotus::Logger.new(tag).tap do |logger|
         logger.level = ::Logger.const_get level
-        request_id = Thread.current[:echo_request_id]
-        if !!request_id
-          logger.progname = "[request_id=#{request_id}]"
-        end
+        logger.formatter = EchoCommon::Logger::Formatter.new
+        logger.formatter.application_name = logger.application_name
       end
     rescue NameError
       raise LogLevelNameError,

--- a/lib/echo_common/logger/formatter.rb
+++ b/lib/echo_common/logger/formatter.rb
@@ -1,0 +1,17 @@
+require 'lotus/logger'
+
+module EchoCommon
+  module Logger
+    class Formatter < ::Lotus::Logger::Formatter
+      def call(severity, time, progname, msg)
+        request_id = Thread.current[:echo_request_id]
+
+        if request_id
+          progname = (progname.to_s + " [request_id=#{request_id}] ").lstrip
+        end
+
+        super severity, time, progname, msg
+      end
+    end
+  end
+end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -41,6 +41,34 @@ describe "Echo configuration" do
       config = TestConfig.new({'LOG_LEVEL' => 'FOO'})
       expect { config.logger }.to raise_error EchoCommon::Configuration::LogLevelNameError
     end
+
+    it "logs with app name" do
+      output = stub_stdout_constant do
+        subject.logger(tag: "test").info("test logger")
+      end
+
+      expect(output).to match /INFO -- \[test\] : test logger/
+
+      output = stub_stdout_constant do
+        subject.logger(tag: "echo").info("test logger, take two!")
+      end
+
+      expect(output).to match /INFO -- \[echo\] : test logger, take two!/
+    end
+
+    it "logs request_id set on thread" do
+      output = stub_stdout_constant do
+        logger = subject.logger tag: "test"
+
+        Thread.current[:echo_request_id] = "1234"
+
+        logger.info("test logger")
+      end
+
+      expect(output).to match /INFO -- \[test\] \[request_id=1234\] : test logger/
+
+      Thread.current[:echo_request_id] = nil
+    end
   end
 
   describe "getting configuration" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,23 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'echo_common'
+
+def stub_stdout_constant
+  begin_block = <<-BLOCK
+    original_verbosity = $VERBOSE
+    $VERBOSE = nil
+    origin_stdout = STDOUT
+    STDOUT = StringIO.new
+  BLOCK
+  TOPLEVEL_BINDING.eval begin_block
+
+  yield
+  return_str = STDOUT.string
+
+  ensure_block = <<-BLOCK
+    STDOUT = origin_stdout
+    $VERBOSE = original_verbosity
+  BLOCK
+  TOPLEVEL_BINDING.eval ensure_block
+
+  return_str
+end


### PR DESCRIPTION
Since some loggers are created before requests, and lives during the
time span of the server, it didn't work to evaluate the thread
echo_request_id during initialization.

The evaluation has to be deferred to the write time.