### PR TITLE
Added common logger class.

### DIFF
--- a/lib/echo_common/configuration.rb
+++ b/lib/echo_common/configuration.rb
@@ -1,5 +1,5 @@
 require 'echo_common/error'
-require 'lotus/logger'
+require 'echo_common/logger'
 
 module EchoCommon
   # Echo Configuration
@@ -54,12 +54,8 @@ module EchoCommon
     #   tag     -  The tag name you want logged lines to be tagged with
     #   level   -  The log level for this logger, defaults to this config
     def logger(tag: nil, level: self[:log_level])
-      ::Lotus::Logger.new(tag).tap do |logger|
+      Logger.new(tag).tap do |logger|
         logger.level = ::Logger.const_get level
-        request_id = Thread.current[:echo_request_id]
-        if !!request_id
-          logger.progname = "[request_id=#{request_id}]"
-        end
       end
     rescue NameError
       raise LogLevelNameError,

--- a/lib/echo_common/logger.rb
+++ b/lib/echo_common/logger.rb
@@ -1,0 +1,21 @@
+require 'lotus/logger'
+
+module EchoCommon
+  class Logger < ::Lotus::Logger
+
+    def initialize(*)
+      super
+    end
+
+    # Overrides ::Logger.add tagging message with request_id
+    def add(*)
+      request_id = Thread.current[:echo_request_id]
+      if !!request_id
+        self.progname = "[request_id=#{request_id}]"
+      end
+
+      super
+    end
+
+  end
+end


### PR DESCRIPTION
Moved the request_id tagging from initializer to the overridden add method.
Turns out we have some instances of the logger which are long lived (e.g. SequelQueryLogs.loggers)

To make sure all log calls are tagged the add method which all log methods delegate to is overridden and message tagged there.