### PR TITLE
Time of day

### DIFF
--- a/lib/echo_common/time_of_day.rb
+++ b/lib/echo_common/time_of_day.rb
@@ -10,6 +10,9 @@ module EchoCommon
     SEC_PER_HOUR = (SEC_PER_MINUTE * 60).freeze
     SEC_PER_DAY = ((SEC_PER_HOUR * 24) - 1).freeze
 
+    # Loads from string, separated by ':'
+    #
+    # Ex. "10:01:12"
     def self.load(string)
       return if string.nil?
 
@@ -17,6 +20,7 @@ module EchoCommon
       new *parts
     end
 
+    # Creates from Ruby's Time or DateTime object
     def self.from_time(time)
       case time
       when Time, DateTime
@@ -26,6 +30,9 @@ module EchoCommon
       end
     end
 
+    # Creates from seconds
+    #
+    # Ex. from_second_of_day(3600) => TimeOfDay.new(1, 0, 0)
     def self.from_second_of_day(seconds)
       fail ArgumentError, "Given more seconds than in one day" if seconds > SEC_PER_DAY
 
@@ -35,6 +42,7 @@ module EchoCommon
       new hour, minute, seconds
     end
 
+    # Dumps a time_of_day to string
     def self.dump(time_of_day)
       return if time_of_day.nil?
 
@@ -56,21 +64,32 @@ module EchoCommon
       freeze
     end
 
-
+    # Second of day this object represents
+    #
+    # Ex. new(1, 0, 1).second_of_day => 3601
     def second_of_day
-      (hour * 60 * 60) +
-      (minute * 60) +
+      (hour * SEC_PER_HOUR) +
+      (minute * SEC_PER_MINUTE) +
       second
     end
 
+    # Adds seconds from this time
+    #
+    # Returns a new object.
     def +(seconds)
       self.class.from_second_of_day [second_of_day + seconds, SEC_PER_DAY].min
     end
 
+    # Subtracts seconds to this time
+    #
+    # Returns a new object.
     def -(seconds)
       self.class.from_second_of_day [second_of_day - seconds, 0].max
     end
 
+    # Gives the next succ to this time
+    #
+    # Adds 1 second.
     def next
       self + 1
     end

--- a/lib/echo_common/time_of_day.rb
+++ b/lib/echo_common/time_of_day.rb
@@ -71,6 +71,11 @@ module EchoCommon
       self.class.from_second_of_day [second_of_day - seconds, 0].max
     end
 
+    def next
+      self + 1
+    end
+    alias succ next
+
 
     def to_s
       [

--- a/lib/echo_common/time_of_day.rb
+++ b/lib/echo_common/time_of_day.rb
@@ -13,11 +13,20 @@ module EchoCommon
     # Loads from string, separated by ':'
     #
     # Ex. "10:01:12"
-    def self.load(string)
-      return if string.nil?
+    def self.load(object)
+      return if object.nil?
 
-      parts = string.split(':').map &:to_i
-      new *parts
+      case object
+      when TimeOfDay
+        object
+      when Time, DateTime
+        from_time object
+      when String
+        parts = object.split(':').map &:to_i
+        new *parts
+      else
+        fail ArgumentError, "Unable to load #{object}."
+      end
     end
 
     # Creates from Ruby's Time or DateTime object

--- a/lib/echo_common/time_of_day.rb
+++ b/lib/echo_common/time_of_day.rb
@@ -22,8 +22,13 @@ module EchoCommon
       when Time, DateTime
         from_time object
       when String
-        parts = object.split(':').map &:to_i
-        new *parts
+        parts = object.split(':')
+
+        if parts.length < 1 || parts.length > 3 || parts.any? { |part| ! part.match /\A\d{1,2}\Z/ }
+          fail ArgumentError, "Invalid string given. Must be like HH:MM:SS. MM and SS is optional."
+        end
+
+        new *parts.map(&:to_i)
       else
         fail ArgumentError, "Unable to load #{object}."
       end

--- a/lib/echo_common/time_of_day.rb
+++ b/lib/echo_common/time_of_day.rb
@@ -3,6 +3,8 @@ module EchoCommon
   #
   # In other words a class representing time without date, nor time zone.
   class TimeOfDay
+    include Comparable
+
     VALID_HOUR = 0..23.freeze
     VALID_MIN_SEC = 0..59.freeze
 

--- a/lib/echo_common/time_of_day.rb
+++ b/lib/echo_common/time_of_day.rb
@@ -1,0 +1,108 @@
+module EchoCommon
+  # Value object represents a time of day
+  #
+  # In other words a class representing time without date, nor time zone.
+  class TimeOfDay
+    VALID_HOUR = 0..23.freeze
+    VALID_MIN_SEC = 0..59.freeze
+
+    SEC_PER_MINUTE = 60.freeze
+    SEC_PER_HOUR = (SEC_PER_MINUTE * 60).freeze
+    SEC_PER_DAY = ((SEC_PER_HOUR * 24) - 1).freeze
+
+    def self.load(string)
+      return if string.nil?
+
+      parts = string.split(':').map &:to_i
+      new *parts
+    end
+
+    def self.from_time(time)
+      case time
+      when Time, DateTime
+        new time.hour, time.min, time.sec
+      else
+        fail ArgumentError, "Expected either Time or DateTime. Got: #{time}."
+      end
+    end
+
+    def self.from_second_of_day(seconds)
+      fail ArgumentError, "Given more seconds than in one day" if seconds > SEC_PER_DAY
+
+      hour =    seconds / SEC_PER_HOUR;   seconds = seconds % SEC_PER_HOUR
+      minute =  seconds / SEC_PER_MINUTE; seconds = seconds % SEC_PER_MINUTE
+
+      new hour, minute, seconds
+    end
+
+    def self.dump(time_of_day)
+      return if time_of_day.nil?
+
+      time_of_day.to_s
+    end
+
+
+
+    attr_reader :hour, :minute, :second
+    alias min minute
+    alias sec second
+
+    def initialize(hour = 0, minute = 0, second = 0)
+      fail ArgumentError, "Invalid hour #{hour}" unless VALID_HOUR.include? hour
+      fail ArgumentError, "Invalid minute #{minute}" unless VALID_MIN_SEC.include? minute
+      fail ArgumentError, "Invalid second #{second}" unless VALID_MIN_SEC.include? second
+
+      @hour, @minute, @second = hour, minute, second
+      freeze
+    end
+
+
+    def second_of_day
+      (hour * 60 * 60) +
+      (minute * 60) +
+      second
+    end
+
+    def +(seconds)
+      self.class.from_second_of_day [second_of_day + seconds, SEC_PER_DAY].min
+    end
+
+    def -(seconds)
+      self.class.from_second_of_day [second_of_day - seconds, 0].max
+    end
+
+
+    def to_s
+      [
+        "%02d" % hour,
+        "%02d" % minute,
+        "%02d" % second
+      ].join(':')
+    end
+
+    def inspect
+      "<#{self.class.name} #{to_s}>"
+    end
+
+
+    def <=>(other)
+      if other.respond_to? :second_of_day
+        second_of_day <=> other.second_of_day
+      end
+    end
+
+    def equal?(other)
+      if other.respond_to? :second_of_day
+        second_of_day == other.second_of_day
+      else
+        false
+      end
+    end
+    alias eql? equal?
+    alias == equal?
+
+    def hash
+      second_of_day.hash
+    end
+  end
+end

--- a/lib/echo_common/time_of_day.rb
+++ b/lib/echo_common/time_of_day.rb
@@ -26,7 +26,7 @@ module EchoCommon
       when String
         parts = object.split(':')
 
-        if parts.length < 1 || parts.length > 3 || parts.any? { |part| ! part.match /\A\d{1,2}\Z/ }
+        if parts.length < 1 || parts.length > 3 || parts.any? { |part| !part.match /\A\d{1,2}\Z/ }
           fail ArgumentError, "Invalid string given. Must be like HH:MM:SS. MM and SS is optional."
         end
 

--- a/lib/echo_common/time_of_day.rb
+++ b/lib/echo_common/time_of_day.rb
@@ -126,17 +126,15 @@ module EchoCommon
 
 
     def <=>(other)
-      if other.respond_to? :second_of_day
-        second_of_day <=> other.second_of_day
-      end
+      second_of_day <=> other.second_of_day
+    rescue NoMethodError => error
+      fail ArgumentError, "comparison of #{other.class} with #{inspect} failed"
     end
 
     def equal?(other)
-      if other.respond_to? :second_of_day
-        second_of_day == other.second_of_day
-      else
-        false
-      end
+      second_of_day == other.second_of_day
+    rescue NoMethodError => error
+      false
     end
     alias eql? equal?
     alias == equal?

--- a/spec/lib/time_of_day_spec.rb
+++ b/spec/lib/time_of_day_spec.rb
@@ -128,6 +128,20 @@ module EchoCommon
           t1, t2, t3, t4
         ]
       end
+
+      it "can be compared with >" do
+        t1 = described_class.new 1
+        t2 = described_class.new 2
+
+        expect(t1 < t2).to eq true
+      end
+
+      it "can be compared with <" do
+        t1 = described_class.new 1
+        t2 = described_class.new 2
+
+        expect(t1 > t2).to eq false
+      end
     end
 
     describe "usage in range" do

--- a/spec/lib/time_of_day_spec.rb
+++ b/spec/lib/time_of_day_spec.rb
@@ -118,5 +118,13 @@ module EchoCommon
         ]
       end
     end
+
+    describe "usage in range" do
+      it "is determined to be included in a range" do
+        expect(described_class.new(0)..described_class.new(2)).to include described_class.new(1)
+        expect(described_class.new(1)..described_class.new(1, 1)).to include described_class.new(1, 0, 1)
+        expect(described_class.new(1)..described_class.new(1, 1)).to_not include described_class.new(1, 1, 1)
+      end
+    end
   end
 end

--- a/spec/lib/time_of_day_spec.rb
+++ b/spec/lib/time_of_day_spec.rb
@@ -9,6 +9,13 @@ module EchoCommon
         expect(described_class.load("03:04:55")).to eq described_class.new(3, 4, 55)
       end
 
+      it "fails on invalid string" do
+        expect { described_class.load("a03:00:00") }.to raise_error ArgumentError
+        expect { described_class.load("03:00:00:01") }.to raise_error ArgumentError
+        expect { described_class.load("3.45") }.to raise_error ArgumentError
+        expect { described_class.load("03;") }.to raise_error ArgumentError
+      end
+
       it "loads a TimeOfDay" do
         expect(described_class.load(described_class.new(10, 1, 2))).to eq described_class.new(10, 1, 2)
       end

--- a/spec/lib/time_of_day_spec.rb
+++ b/spec/lib/time_of_day_spec.rb
@@ -9,6 +9,10 @@ module EchoCommon
         expect(described_class.load("03:04:55")).to eq described_class.new(3, 4, 55)
       end
 
+      it "loads a TimeOfDay" do
+        expect(described_class.load(described_class.new(10, 1, 2))).to eq described_class.new(10, 1, 2)
+      end
+
       it "loads nil" do
         expect(described_class.load(nil)).to eq nil
       end

--- a/spec/lib/time_of_day_spec.rb
+++ b/spec/lib/time_of_day_spec.rb
@@ -90,7 +90,7 @@ module EchoCommon
         expect(subject + 100000000).to eq described_class.new(23, 59, 59)
       end
 
-      it "substracts no more than down to 0" do
+      it "subtracts no more than down to 0" do
         expect(subject - 100000000).to eq described_class.new(0, 0, 0)
       end
     end

--- a/spec/lib/time_of_day_spec.rb
+++ b/spec/lib/time_of_day_spec.rb
@@ -1,0 +1,122 @@
+require 'echo_common/time_of_day'
+
+module EchoCommon
+  describe TimeOfDay do
+    describe ".load" do
+      it "loads expected values" do
+        expect(described_class.load("10:01:02")).to eq described_class.new(10, 1, 2)
+        expect(described_class.load("00:01:02")).to eq described_class.new(0, 1, 2)
+        expect(described_class.load("03:04:55")).to eq described_class.new(3, 4, 55)
+      end
+
+      it "loads nil" do
+        expect(described_class.load(nil)).to eq nil
+      end
+    end
+
+    describe ".from_time" do
+      it "constructs from Time" do
+        expect(described_class.from_time(Time.new 2002, 10, 31, 2, 3, 4)).to eq(
+          described_class.new(2, 3, 4)
+        )
+      end
+
+      it "constructs from DateTime" do
+        expect(described_class.from_time(DateTime.new 2002, 10, 31, 2, 3, 4)).to eq(
+          described_class.new(2, 3, 4)
+        )
+      end
+    end
+
+    describe ".from_second_of_day" do
+      it "constructs correctly when seconds is within one day" do
+        expect(described_class.from_second_of_day(1)).to eq described_class.new(0, 0, 1)
+        expect(described_class.from_second_of_day(3660)).to eq described_class.new(1, 1, 0)
+        expect(described_class.from_second_of_day(82800)).to eq described_class.new(23, 0, 0)
+      end
+
+      it "fails when given more seconds than in one day" do
+        expect {
+          described_class.from_second_of_day described_class::SEC_PER_DAY + 1
+        }.to raise_error ArgumentError
+      end
+    end
+
+    describe ".dump" do
+      it "dumps to expected string" do
+        expect(described_class.dump(described_class.new(10, 1, 02))).to eq "10:01:02"
+        expect(described_class.dump(described_class.new(0, 1, 02))).to eq "00:01:02"
+        expect(described_class.dump(described_class.new(3, 4, 55))).to eq "03:04:55"
+      end
+
+      it "dumps nil" do
+        expect(described_class.dump(nil)).to eq nil
+      end
+    end
+
+
+    subject { described_class.new 13, 2, 15 }
+
+    it { expect(subject.hour).to eq 13 }
+    it { expect(subject.minute).to eq 2 }
+    it { expect(subject.second).to eq 15 }
+
+    describe "#initialize" do
+      it "fails on invalid values" do
+        expect { described_class.new -1 }.to          raise_error ArgumentError
+        expect { described_class.new 0, 60 }.to       raise_error ArgumentError
+        expect { described_class.new 24 }.to          raise_error ArgumentError
+        expect { described_class.new 23, 1, 102 }.to  raise_error ArgumentError
+      end
+    end
+
+    describe "#second_of_day" do
+      it "is 3600 when time is 01:00" do
+        expect(described_class.new(1).second_of_day).to eq 3600
+      end
+
+      it "is 43200 when time is 12:01:01" do
+        expect(described_class.new(12, 1, 1).second_of_day).to eq 43261
+      end
+    end
+
+    describe "calculations" do
+      it "adds seconds" do
+        expect(subject + 10).to eq described_class.new(13, 2, 25)
+        expect(subject - 5).to eq described_class.new(13, 2, 10)
+      end
+
+      it "adds no more than up to max a day" do
+        expect(subject + 100000000).to eq described_class.new(23, 59, 59)
+      end
+
+      it "substracts no more than down to 0" do
+        expect(subject - 100000000).to eq described_class.new(0, 0, 0)
+      end
+    end
+
+    describe "equality" do
+      it "is considered equal when second_of_day is the same" do
+        other = described_class.new 13, 2, 15
+
+        expect(subject).to be_equal other
+        expect(subject).to be_eql other
+        expect(subject).to eq other
+        expect(subject.hash).to eq other.hash
+      end
+    end
+
+    describe "comparable" do
+      it "is comparable" do
+        t1 = described_class.new 1, 2, 3
+        t2 = described_class.new 1, 2, 4
+        t3 = described_class.new 1, 3, 1
+        t4 = described_class.new 2, 0, 0
+
+        expect([t2, t1, t3, t4].sort).to eq [
+          t1, t2, t3, t4
+        ]
+      end
+    end
+  end
+end

--- a/spec/lib/time_of_day_spec.rb
+++ b/spec/lib/time_of_day_spec.rb
@@ -115,6 +115,10 @@ module EchoCommon
         expect(subject).to eq other
         expect(subject.hash).to eq other.hash
       end
+
+      it "is not equal object of other type" do
+        expect(subject == "foo").to eq false
+      end
     end
 
     describe "comparable" do
@@ -141,6 +145,12 @@ module EchoCommon
         t2 = described_class.new 2
 
         expect(t1 > t2).to eq false
+      end
+
+      it "fails if you incomparable objects" do
+        expect {
+          subject < "foo"
+        }.to raise_error ArgumentError
       end
     end
 


### PR DESCRIPTION
Introduserer en klasse for å representere på tid på døgnet, uten dato eller tidssone. Til bruk for for eksempel programmer som gjentas, med fast start- og slutt tidspunkt.

Klassen har `load` og `dump`, så vi kan benytte den sammen med Lotus for innlesing og dumping av verdi fra databasen.

Den støtter enkel `+/-` operasjon, er sammenlignbar og kan benyttes i range ala `(t1..t2).include? t3`