### PR TITLE
create dynamic class for type

### DIFF
--- a/lib/echo_common/hanami/models/coercer/pg_array.rb
+++ b/lib/echo_common/hanami/models/coercer/pg_array.rb
@@ -6,20 +6,23 @@ module EchoCommon
   module Hanami
     module Models
       module Coercer
-        class PGArray
+        class PGArray < ::Hanami::Model::Coercer
+          @@type = nil
+
           def self.for(type)
-            new type
+            PGArray.const_get("#{type.to_s.capitalize}")
+          rescue
+            PGArray.const_set(
+              "#{type.to_s.capitalize}",
+              Class.new(PGArray) { @@type = type }
+            )
           end
 
-          def initialize(type = nil)
-            @type = type
+          def self.dump(value)
+            ::Sequel.pg_array(value, @@type) rescue nil
           end
 
-          def dump(value)
-            ::Sequel.pg_array(value, @type) rescue nil
-          end
-
-          def load(value)
+          def self.load(value)
             ::Kernel.Array(value) unless value.nil?
           end
         end

--- a/lib/echo_common/hanami/models/coercer/pg_array.rb
+++ b/lib/echo_common/hanami/models/coercer/pg_array.rb
@@ -9,6 +9,20 @@ module EchoCommon
         class PGArray < ::Hanami::Model::Coercer
           @@type = nil
 
+
+          # Returns a type specific subclass of PGArray.
+          # If the class is already defined returns it, otherwise
+          # creates a new dynamic class for the given type.
+          # The type is communicated to ::Sequel.pg_array
+          #
+          # Example:
+          #
+          # ::EchoCommon::Hanami::Models::Coercer::PGArray.for(:varchar)
+          # => EchoCommon::Hanami::Models::Coercer::PGArray::Varchar
+          #
+          # ::EchoCommon::Hanami::Models::Coercer::PGArray.for(:integer)
+          # => EchoCommon::Hanami::Models::Coercer::PGArray::Integer
+          #
           def self.for(type)
             PGArray.const_get("#{type.to_s.capitalize}")
           rescue

--- a/spec/lib/hanami/models/coercer/pg_array_spec.rb
+++ b/spec/lib/hanami/models/coercer/pg_array_spec.rb
@@ -3,21 +3,29 @@ require 'echo_common/hanami/models/coercer/pg_array'
 
 describe EchoCommon::Hanami::Models::Coercer::PGArray do
 
-  subject { described_class.new }
-
   describe ".load" do
     it "loads an array" do
       array = ["foo", "bar"]
-      expect(subject.load(array)).to eq array
+      expect(described_class.load(array)).to eq array
     end
   end
 
   describe ".dump" do
     it "dumps an array" do
-      dump = subject.dump(["foo", "bar"])
+      dump = described_class.dump(["foo", "bar"])
       expect(dump).to be_a ::Sequel::Postgres::PGArray
       expect(dump.to_a).to eq ["foo", "bar"]
     end
   end
 
+  describe ".for" do
+    it "creates a dynamic class for the type" do
+      typed_coercer = described_class.for(:varchar)
+      expect(typed_coercer).to be < EchoCommon::Hanami::Models::Coercer::PGArray
+    end
+
+    it "retrurns same class for multiple invocations" do
+      expect(described_class.for(:varchar)).to eq(described_class.for(:varchar))
+    end
+  end
 end


### PR DESCRIPTION
Hanami mapping var ikke så glad i instanser, da den forventer en klasse.

Endret slik at factory returnerer en dynamisk klasse i samme namespace som arver fra PGArray.

Eksempel på bruk i mapping:
```
attribute :main_artists, ::EchoCommon::Hanami::Models::Coercer::PGArray.for(:varchar)
```

connected to https://github.com/gramo-org/echo/issues/188