### PR TITLE
EchoCommon elastic client#new has equal arguments as elastic gem.

### DIFF
--- a/spec/lib/services/elasticsearch/client_spec.rb
+++ b/spec/lib/services/elasticsearch/client_spec.rb
@@ -4,20 +4,22 @@ describe EchoCommon::Services::Elasticsearch::Client do
 
   let(:config) do
     {
-      host: "127.0.0.1",
-      port: 9200,
-      user: "",
-      password: "",
-      scheme: "http",
+      indices_mapping_glob: "foo/bar/*.json",
       index_prefix: "testing_",
-      indices_mapping_glob: "foo/bar/*.json"
+      hosts: [{
+        host: "127.0.0.1",
+        port: 9200,
+        user: "",
+        password: "",
+        scheme: "http",
+      }]
     }
   end
 
   let(:client_class) { double }
   let(:elasticsearch_client) { double indices: double }
   let(:client) do
-    described_class.new logger: double, config: config, client_class: client_class
+    described_class.new **config, client_class: client_class
   end
 
   before do


### PR DESCRIPTION
This way it is easier to pass in other options than only configuration
for the host. We can also fill in request timeouts etc as if it is the
"native" elastic search gem's client.

We also delete arguments our client cares about so they don't get in to
the elastic's client new argument list.