### PR TITLE
En-til-mange relasjon

### DIFF
--- a/lib/echo_common/entity/relation/many.rb
+++ b/lib/echo_common/entity/relation/many.rb
@@ -1,0 +1,42 @@
+require 'forwardable'
+
+module EchoCommon
+  class Entity
+    module Relation
+      # Class representing a relation between one-to-many objects
+      #
+      # - It acts as an array, with minimal public API.
+      # - It keeps it's @owner, which is the object owning all the objects in
+      #   this relation.
+      #
+      # For more advanced relation operation, like filter relation based on time, date or
+      # other state you can create a subclass and build upon #select and #reject.
+      class Many
+        extend Forwardable
+
+        def_delegators :@collection,
+          :<<, :delete,
+          :each, :each_with_index, :map,
+          :length, :first, :last, :[],
+          :any?, :empty?, :include?,
+          :==, :equal?, :eql?, :eq?, :hash
+
+        def initialize(owner, collection = [])
+          @owner = owner
+          @collection = collection
+        end
+
+
+        private
+
+        def select(&block)
+          self.class.new @owner, @collection.select(&block)
+        end
+
+        def reject(&block)
+          self.class.new @owner, @collection.reject(&block)
+        end
+      end
+    end
+  end
+end

--- a/lib/echo_common/entity/relation/many.rb
+++ b/lib/echo_common/entity/relation/many.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'echo_common/error'
 
 module EchoCommon
   class Entity
@@ -15,16 +16,40 @@ module EchoCommon
         extend Forwardable
 
         def_delegators :@collection,
-          :<<, :delete,
+          :delete,
           :each, :each_with_index, :map,
           :length, :first, :last, :[],
           :any?, :empty?, :include?,
           :==, :equal?, :eql?, :eq?, :hash
 
+
+        class AlreadyAddedError < EchoCommon::Error
+          attr_reader :object, :relation
+
+          def initialize(object, relation)
+            @object = object
+            @relation = relation
+
+            super "#{object} already added to #{relation}."
+          end
+        end
+
         def initialize(owner, collection = [])
           @owner = owner
           @collection = collection
         end
+
+        def push(object)
+          raise AlreadyAddedError.new(object, self) if @collection.include? object
+          @collection.push object
+        end
+        alias_method :<<, :push
+
+
+        def inspect
+          "<#{self.class.name} owner: #{@owner}, length: #{length}>"
+        end
+        alias_method :to_s, :inspect
 
 
         private

--- a/lib/echo_common/entity/relation/many.rb
+++ b/lib/echo_common/entity/relation/many.rb
@@ -47,7 +47,7 @@ module EchoCommon
 
 
         def inspect
-          "<#{self.class.name} owner: #{@owner}, length: #{length}>"
+          "<#{self.class.name} owner: #{@owner.class.name}, length: #{length}>"
         end
         alias_method :to_s, :inspect
 

--- a/spec/lib/entity/relation/many_spec.rb
+++ b/spec/lib/entity/relation/many_spec.rb
@@ -15,11 +15,20 @@ module EchoCommon
     end
 
     it "can add objects" do
-      obj = double
+      obj = "obj"
       subject << obj
 
       expect(subject).to_not be_empty
       expect(subject).to eq [obj]
+    end
+
+    it "raises error when adding duplicates" do
+      obj = "obj"
+      subject << obj
+
+      expect {
+        subject << obj
+      }.to raise_error Entity::Relation::Many::AlreadyAddedError
     end
   end
 end

--- a/spec/lib/entity/relation/many_spec.rb
+++ b/spec/lib/entity/relation/many_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'echo_common/entity/relation/many'
+
+
+module EchoCommon
+  describe Entity::Relation::Many do
+    class TestRelation < Entity::Relation::Many
+    end
+
+    let(:owner) { double :owner }
+    let(:subject) { TestRelation.new owner }
+
+    it "is empty to begin with" do
+      expect(subject).to be_empty
+    end
+
+    it "can add objects" do
+      obj = double
+      subject << obj
+
+      expect(subject).to_not be_empty
+      expect(subject).to eq [obj]
+    end
+  end
+end


### PR DESCRIPTION
Klasse for representasjon av en-til-mange relasjoner.

Trukket ut kode vi brukte i [program relasjon fra echo](https://github.com/gramo-org/echo/blob/add-group/lib/echo/playtime_registry/entities/channel/program_relation.rb) da vi og trenger liknende konstruksjon for å representere [groppe medlemsskap relasjon](https://github.com/gramo-org/echo/blob/add-group/lib/echo/discography/entities/group/membership_relation.rb).