### PR TITLE
only create indices at start of suite

### DIFF
--- a/lib/echo_common/rspec/helpers/elasticsearch_helper.rb
+++ b/lib/echo_common/rspec/helpers/elasticsearch_helper.rb
@@ -115,6 +115,12 @@ module EchoCommon
 
           def teardown_indices
             EchoCommon::Services::Elasticsearch.delete_all_indices
+            EchoCommon::Services::Elasticsearch.client.refresh_indices
+          end
+
+          def purge_indices!
+            teardown_indices
+            setup_and_refresh_indices
           end
 
           class TestCluster

--- a/lib/echo_common/rspec/helpers/elasticsearch_helper.rb
+++ b/lib/echo_common/rspec/helpers/elasticsearch_helper.rb
@@ -80,15 +80,30 @@ module EchoCommon
               include ElasticsearchSpecHelper
 
               around do |example|
-                begin
-                  TestCluster.start
-                  BlockingProxyClient.route = true
-                  setup_and_refresh_indices
+                with_routing_turned_on do
                   example.run
-                ensure
-                  teardown_indices
-                  BlockingProxyClient.route = false
                 end
+              end
+
+
+              before(:all) do
+                with_routing_turned_on do
+                  TestCluster.start
+                  setup_and_refresh_indices
+                end
+              end
+
+              after(:all) do
+                with_routing_turned_on do
+                  teardown_indices
+                end
+              end
+
+              def with_routing_turned_on
+                BlockingProxyClient.route = true
+                yield
+              ensure
+                BlockingProxyClient.route = false
               end
             end
           end


### PR DESCRIPTION
Forbedrer ytelsen i systemspecen ved å kun opprette indekser i begynnelsen av test suiten.

Fra:
```
echo git:(master) 👾  rspec ./spec/system/playtime_registry/programs_spec.rb
I, [2016-08-22T14:27:08.616878 #15092]  INFO -- : ** [Raven] Raven 0.15.6 configured not to send errors.
.......................

Finished in 4.75 seconds (files took 1.51 seconds to load)
23 examples, 0 failures
```

Til:
```
echo git:(master) 👾  rspec ./spec/system/playtime_registry/programs_spec.rb
I, [2016-08-22T14:41:37.407284 #16323]  INFO -- : ** [Raven] Raven 0.15.6 configured not to send errors.
.......................

Finished in 1.32 seconds (files took 1.5 seconds to load)
```