### PR TITLE
add current user locale to authentication controller

### DIFF
--- a/lib/echo_common/hanami/controllers/authentication.rb
+++ b/lib/echo_common/hanami/controllers/authentication.rb
@@ -45,6 +45,12 @@ module EchoCommon
         rescue JWT::ExpiredSignature
           nil
         end
+
+        def current_user_locale
+          jwt.get('data.user.locale')
+        rescue JWT::ExpiredSignature
+          nil
+        end
       end
     end
   end

--- a/lib/echo_common/rspec/helpers/jwt_auth_helper.rb
+++ b/lib/echo_common/rspec/helpers/jwt_auth_helper.rb
@@ -10,7 +10,8 @@ module EchoCommon
           {
             id: SecureRandom.uuid,
             name: 'Herp Derp',
-            email: 'herpderp@skalar.no'
+            email: 'herpderp@skalar.no',
+            locale: 'no'
           }
         end
 


### PR DESCRIPTION
Exposes the current user locale from the jwt token through the authentication controller.

related to https://github.com/gramo-org/echo/pull/977