### PR TITLE
Fix pg array.for

### DIFF
--- a/lib/echo_common/hanami/models/coercer/pg_array.rb
+++ b/lib/echo_common/hanami/models/coercer/pg_array.rb
@@ -24,12 +24,9 @@ module EchoCommon
           # => EchoCommon::Hanami::Models::Coercer::PGArray::Integer
           #
           def self.for(type)
-            PGArray.const_get("#{type.to_s.capitalize}")
+            PGArray.const_get(const_name(type))
           rescue
-            PGArray.const_set(
-              "#{type.to_s.capitalize}",
-              Class.new(PGArray) { @@type = type }
-            )
+            PGArray.const_set(const_name(type), Class.new(PGArray) { @@type = type })
           end
 
           def self.dump(value)
@@ -38,6 +35,12 @@ module EchoCommon
 
           def self.load(value)
             ::Kernel.Array(value) unless value.nil?
+          end
+
+          # Makes const mapping able to handle values with spaces
+          # e.g. :'timestamp without time zone' => :Timestamp_With_Time_Zone
+          def self.const_name(type)
+            type.to_s.split(' ').map(&:capitalize).join('_')
           end
         end
       end

--- a/lib/echo_common/hanami/models/coercer/pg_array.rb
+++ b/lib/echo_common/hanami/models/coercer/pg_array.rb
@@ -7,40 +7,43 @@ module EchoCommon
     module Models
       module Coercer
         class PGArray < ::Hanami::Model::Coercer
-          @@type = nil
+          @type = nil
 
+          class << self
+            attr_accessor :type
 
-          # Returns a type specific subclass of PGArray.
-          # If the class is already defined returns it, otherwise
-          # creates a new dynamic class for the given type.
-          # The type is communicated to ::Sequel.pg_array
-          #
-          # Example:
-          #
-          # ::EchoCommon::Hanami::Models::Coercer::PGArray.for(:varchar)
-          # => EchoCommon::Hanami::Models::Coercer::PGArray::Varchar
-          #
-          # ::EchoCommon::Hanami::Models::Coercer::PGArray.for(:integer)
-          # => EchoCommon::Hanami::Models::Coercer::PGArray::Integer
-          #
-          def self.for(type)
-            PGArray.const_get(const_name(type))
-          rescue
-            PGArray.const_set(const_name(type), Class.new(PGArray) { @@type = type })
-          end
+            # Returns a type specific subclass of PGArray.
+            # If the class is already defined returns it, otherwise
+            # creates a new dynamic class for the given type.
+            # The type is communicated to ::Sequel.pg_array
+            #
+            # Example:
+            #
+            # ::EchoCommon::Hanami::Models::Coercer::PGArray.for(:varchar)
+            # => EchoCommon::Hanami::Models::Coercer::PGArray::Varchar
+            #
+            # ::EchoCommon::Hanami::Models::Coercer::PGArray.for(:integer)
+            # => EchoCommon::Hanami::Models::Coercer::PGArray::Integer
+            #
+            def for(type)
+              PGArray.const_get(const_name(type))
+            rescue
+              PGArray.const_set(const_name(type), Class.new(PGArray) { @type = type })
+            end
 
-          def self.dump(value)
-            ::Sequel.pg_array(value, @@type) rescue nil
-          end
+            def dump(value)
+              ::Sequel.pg_array(value, @type) rescue nil
+            end
 
-          def self.load(value)
-            ::Kernel.Array(value) unless value.nil?
-          end
+            def load(value)
+              ::Kernel.Array(value) unless value.nil?
+            end
 
-          # Makes const mapping able to handle values with spaces
-          # e.g. :'timestamp without time zone' => :Timestamp_With_Time_Zone
-          def self.const_name(type)
-            type.to_s.split(' ').map(&:capitalize).join('_')
+            # Makes const mapping able to handle values with spaces
+            # e.g. :'timestamp without time zone' => :Timestamp_With_Time_Zone
+            def const_name(type)
+              type.to_s.split(' ').map(&:capitalize).join('_')
+            end
           end
         end
       end

--- a/spec/lib/hanami/models/coercer/pg_array_spec.rb
+++ b/spec/lib/hanami/models/coercer/pg_array_spec.rb
@@ -27,5 +27,17 @@ describe EchoCommon::Hanami::Models::Coercer::PGArray do
     it "retrurns same class for multiple invocations" do
       expect(described_class.for(:varchar)).to eq(described_class.for(:varchar))
     end
+
+    it 'supports spaces in the type name' do
+      expect(described_class.for(:'timestamp with time zone')).to be(
+        EchoCommon::Hanami::Models::Coercer::PGArray::Timestamp_With_Time_Zone
+      )
+    end
+
+    it 'returns correct type for class' do
+      expect(described_class.for(:varchar).type).to eq(:varchar)
+      expect(described_class.for(:'timestamp with time zone').type).to eq(:'timestamp with time zone')
+      expect(described_class.for(:varchar).type).to eq(:varchar)
+    end
   end
 end


### PR DESCRIPTION
While adding support for types with space in name, like [timestamp with time zone](https://github.com/jeremyevans/sequel/blob/master/lib/sequel/extensions/pg_array.rb#L531) i noticed the implementation was fundamentally broken. When I wrote this I was pretty fresh to ruby, and I though class variables were unique for a class, but Ruby class variables are in fact class hierarchy variables, meaning they are shared between all descendants of a class. So what was happening here was that all descendant classes where referencing the same variable, and the last call to PGArray.for was changing the value for all descendants. 

I added some tests proving the behaviour and fixed the implementation.

The diff has some whitespace changes, so can be better viewed with this: https://github.com/gramo-org/echo_common/pull/40/files?w=1