### PR TITLE
Fixed bug with state machine predicate for initial state.

### DIFF
--- a/lib/echo_common/state_machine/machine.rb
+++ b/lib/echo_common/state_machine/machine.rb
@@ -43,7 +43,7 @@ module EchoCommon
 
             define_event_can_method_for name, from: transition_from_states, to: transition_to_state, guard: guard
             define_event_method_for     name, to: transition_to_state
-            define_state_predicate_for  transition_to_state
+            define_state_predicate_for  transition_from_states | [transition_to_state]
           end
 
           private
@@ -100,9 +100,14 @@ module EchoCommon
             end
           end
 
-          def define_state_predicate_for(state_name)
-            define_method("#{state_name}?") do
-              state == state_name
+          def define_state_predicate_for(state_names)
+            state_names.each do |state_name|
+              predicate = "#{state_name}?"
+              next if respond_to? predicate
+              
+              define_method predicate do
+                state == state_name
+              end
             end
           end
         end

--- a/spec/lib/state_machine/machine_spec.rb
+++ b/spec/lib/state_machine/machine_spec.rb
@@ -2,6 +2,17 @@ require "spec_helper"
 require "echo_common/state_machine/machine"
 
 describe EchoCommon::StateMachine::Machine do
+  class InitialStateSubject
+    include EchoCommon::StateMachine::Machine
+
+    attr_accessor :state
+    event :go, from: "resting", to: "going"
+
+    def initialize(state = "resting")
+      @state = state
+    end
+  end
+  
   class Subject
     include EchoCommon::StateMachine::Machine
 
@@ -34,6 +45,10 @@ describe EchoCommon::StateMachine::Machine do
     event :stop, from: ["running", "walking"], to: "standing"
     event :sit, from: "standing", to: "sitting", guard: :have_chair?
     event :stand, from: "sitting", to: "standing"
+  end
+
+  it "has a predicate for initial state" do
+    expect(InitialStateSubject.new).to be_resting
   end
 
   subject { Subject.new }


### PR DESCRIPTION
This worked if the initial state was possible to transition to, but when
init state only was an initial state no predicate method was created.