### PR TITLE
Entity#hash is same for all objects of same class and with same id + equality fixes

### DIFF
--- a/lib/echo_common/entity.rb
+++ b/lib/echo_common/entity.rb
@@ -28,5 +28,11 @@ module EchoCommon
 
       self.class.hash ^ id.hash
     end
+
+    def ==(other)
+      other.object_id == object_id || other.instance_of?(self.class) && !id.nil? && other.id == id
+    end
+
+    alias eql? ==
   end
 end

--- a/lib/echo_common/entity.rb
+++ b/lib/echo_common/entity.rb
@@ -14,12 +14,19 @@ module EchoCommon
       attrs.each do |attr|
         self.attributes attr
         define_method "#{attr}=".to_sym do |val|
-          raise CreateOnlyAttributeError.new "Illegal to set #{attr} more than once" if instance_variable_defined?("@#{attr}")
+          if instance_variable_defined?("@#{attr}")
+            raise CreateOnlyAttributeError.new "Illegal to set #{attr} more than once"
+          end
+
           instance_variable_set "@#{attr}", val
         end
       end
     end
 
+    def hash
+      return super if id.nil?
 
+      self.class.hash ^ id.hash
+    end
   end
 end

--- a/spec/lib/entity_spec.rb
+++ b/spec/lib/entity_spec.rb
@@ -1,8 +1,12 @@
 require 'echo_common/entity'
 
 module EchoCommon
-
   class AnEntity < Entity
+    create_only_attributes :foo
+    create_only_attributes :bar, :zap
+  end
+  
+  class AnotherEntity < Entity
     create_only_attributes :foo
     create_only_attributes :bar, :zap
   end
@@ -47,6 +51,22 @@ module EchoCommon
         it "raieses an error when trying to set an attribute to nil" do
           expect {subject.foo=nil}.not_to raise_error
         end
+      end
+    end
+  end
+
+  describe Entity do
+    describe '#hash' do
+      it 'is the same for a equal class with same id' do
+        expect(AnEntity.new(id: 1).hash).to eq AnEntity.new(id: 1).hash
+      end
+
+      it 'is different for two entities without ID' do
+        expect(AnEntity.new(id: nil).hash).to_not eq AnEntity.new(id: nil).hash
+      end
+
+      it 'is different for different class with same id' do
+        expect(AnEntity.new(id: 1).hash).to_not eq AnotherEntity.new(id: 1).hash
       end
     end
   end

--- a/spec/lib/entity_spec.rb
+++ b/spec/lib/entity_spec.rb
@@ -56,6 +56,39 @@ module EchoCommon
   end
 
   describe Entity do
+    describe '#==' do
+      it 'is true for equal class with same id' do
+        expect(AnEntity.new(id: 1)).to eq AnEntity.new(id: 1)
+      end
+
+      it 'is false for two entities without ID' do
+        expect(AnEntity.new(id: nil)).to_not eq AnEntity.new(id: nil)
+      end
+
+      it 'is true for two one without ID' do
+        entity = AnEntity.new(id: nil)
+        expect(entity).to eq entity
+      end
+
+      it 'is false for different class with same id' do
+        expect(AnEntity.new(id: 1)).to_not eq AnotherEntity.new(id: 1)
+      end
+    end
+
+    describe '#eql?' do
+      it 'is true for equal class with same id' do
+        expect(AnEntity.new(id: 1)).to be_eql AnEntity.new(id: 1)
+      end
+
+      it 'is false for two entities without ID' do
+        expect(AnEntity.new(id: nil)).to_not be_eql AnEntity.new(id: nil)
+      end
+
+      it 'is false for different class with same id' do
+        expect(AnEntity.new(id: 1)).to_not be_eql AnotherEntity.new(id: 1)
+      end
+    end
+
     describe '#hash' do
       it 'is the same for a equal class with same id' do
         expect(AnEntity.new(id: 1).hash).to eq AnEntity.new(id: 1).hash

--- a/spec/lib/entity_spec.rb
+++ b/spec/lib/entity_spec.rb
@@ -102,5 +102,26 @@ module EchoCommon
         expect(AnEntity.new(id: 1).hash).to_not eq AnotherEntity.new(id: 1).hash
       end
     end
+
+    describe 'used as key in a hash' do
+      it 'works as expected' do
+        a = AnEntity.new id: :a
+        a2 = AnEntity.new id: :a
+        b = AnEntity.new id: :b
+        c = AnotherEntity.new id: :a
+        d = AnEntity.new id: nil
+
+        hash = {}
+        hash[a] = :a
+        hash[b] = :b
+        hash[c] = :c
+        hash[d] = :d
+
+        expect(hash[a2]).to eq :a
+        expect(hash[b]).to eq :b
+        expect(hash[c]).to eq :c
+        expect(hash[d]).to eq :d
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows for the entity to be used as a key in a hash.

https://github.com/rails/rails/blob/c83f28fffe8b18ee75822394a11f446c05f692fd/activerecord/lib/active_record/core.rb#L432
was used as an inspiration.

Also fixed `#==` and `#eql?`