### PR TITLE
En as default locale for test user

### DIFF
--- a/lib/echo_common/hanami/controllers/authentication.rb
+++ b/lib/echo_common/hanami/controllers/authentication.rb
@@ -36,20 +36,18 @@ module EchoCommon
 
         def authenticated?
           jwt.get('data.authenticated') == true && !current_user_id.nil?
-        rescue JWT::ExpiredSignature
+        rescue JWT::DecodeError
           false
         end
 
         def current_user_id
           jwt.get('data.user.id')
-        rescue JWT::ExpiredSignature
+        rescue JWT::DecodeError
           nil
         end
 
         def current_user_locale
-          jwt.get('data.user.locale')
-        rescue JWT::ExpiredSignature
-          nil
+          jwt.get('data.user.locale') if authenticated?
         end
       end
     end

--- a/lib/echo_common/hanami/controllers/jwt.rb
+++ b/lib/echo_common/hanami/controllers/jwt.rb
@@ -12,15 +12,16 @@ module EchoCommon
       module Jwt
         def jwt
           @jwt ||= begin
-            token = nil
+            header = params.env['HTTP_AUTHORIZATION']
+            token = params.raw[:token] || params.raw['token']
 
-            jwt = if header = params.env['HTTP_AUTHORIZATION']
+            jwt = if header
               EchoCommon::Services::Jwt.from_http_header header
-            elsif token = params.raw[:token] || params.raw['token']
+            elsif token
               EchoCommon::Services::Jwt.decode token
             end
 
-            halt 401, "Signature has expired" if jwt.nil?
+            raise JWT::ExpiredSignature if jwt.nil?
             jwt
           end
         end

--- a/lib/echo_common/rspec/helpers/jwt_auth_helper.rb
+++ b/lib/echo_common/rspec/helpers/jwt_auth_helper.rb
@@ -11,7 +11,7 @@ module EchoCommon
             id: SecureRandom.uuid,
             name: 'Herp Derp',
             email: 'herpderp@skalar.no',
-            locale: 'no'
+            locale: 'en'
           }
         end
 

--- a/spec/lib/hanami/controllers/authentication_spec.rb
+++ b/spec/lib/hanami/controllers/authentication_spec.rb
@@ -16,7 +16,7 @@ describe EchoCommon::Hanami::Controllers::Authentication do
   subject { AuthenticationControllerTest.new }
 
   let(:user_id) { SecureRandom.uuid }
-  let(:user)    { { 'id' => user_id } }
+  let(:user)    { { 'id' => user_id, 'locale' => 'en' } }
   let(:payload) { { 'data' => { 'authenticated' => true, 'user' => user } } }
 
   describe '#current_user_id' do
@@ -60,6 +60,20 @@ describe EchoCommon::Hanami::Controllers::Authentication do
         .and_raise JWT::ExpiredSignature
 
       expect(subject.send(:authenticated?)).to eq false
+    end
+  end
+
+  describe '#current_user_locale' do
+    it 'gets locale from jwt' do
+      subject.jwt = EchoCommon::Services::Jwt::Token.new [payload]
+
+      expect(subject.send(:current_user_locale)).to eq 'en'
+    end
+
+    it 'is nil if token has expired' do
+      expect(subject).to receive(:jwt)
+        .and_raise JWT::DecodeError.new('Not enough or too many segments')
+      expect(subject.send(:current_user_locale)).to be_nil
     end
   end
 end


### PR DESCRIPTION
To make https://github.com/gramo-org/echo/pull/2530 work.

- Rescue `JWT::DecodeError`, not only `ExpiredSignature`. For the onboard controller the `token` param includes a non-JWT token, which makes the code trip when we try to extract locale attribute from that token. I think if we fail decode for some reason we consider user not to be authenticated is ok(?).
- Default locale in test helper is `en`.