### PR TITLE
TimeOfDay::load supports xmlschema formatted timestamps.

### DIFF
--- a/lib/echo_common/time_of_day.rb
+++ b/lib/echo_common/time_of_day.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module EchoCommon
   # Value object represents a time of day
   #
@@ -24,10 +26,14 @@ module EchoCommon
       when Time, DateTime
         from_time object
       when String
+        parsed = try_parse_xmlschema object
+        return load parsed if parsed
+
         parts = object.split(':')
 
         if parts.length < 1 || parts.length > 3 || parts.any? { |part| !part.match /\A\d{1,2}\Z/ }
-          fail ArgumentError, "Invalid string given. Must be like HH:MM:SS. MM and SS is optional."
+          fail ArgumentError,
+               "Invalid string ('#{object}') given. Must be like HH:MM:SS. MM and SS is optional."
         end
 
         new *parts.map(&:to_i)
@@ -63,6 +69,12 @@ module EchoCommon
       minute =  seconds / SEC_PER_MINUTE; seconds = seconds % SEC_PER_MINUTE
 
       new hour, minute, seconds
+    end
+
+    def self.try_parse_xmlschema(string)
+      DateTime.xmlschema string
+    rescue ArgumentError
+      nil
     end
 
     # Dumps a time_of_day to string

--- a/spec/lib/time_of_day_spec.rb
+++ b/spec/lib/time_of_day_spec.rb
@@ -21,6 +21,11 @@ module EchoCommon
         expect(described_class.load("03:04:55")).to eq described_class.new(3, 4, 55)
       end
 
+      it 'loads time with dates, tz ignored' do
+        expect(described_class.load("2016-01-06T03:04:55+01:00")).to eq described_class.new(3, 4, 55)
+        expect(described_class.load("2016-01-06T03:04:55+02:00")).to eq described_class.new(3, 4, 55)
+      end
+
       it "fails on invalid string" do
         expect { described_class.load("a03:00:00") }.to raise_error ArgumentError
         expect { described_class.load("03:00:00:01") }.to raise_error ArgumentError


### PR DESCRIPTION
I'm not sure if this has ever worked as expected. Seems to me that we store XML formatted strings in our database, like:

```sql
select created_at, data from events where name = 'playtime_report_airing_gap_detected_ignored' and aggregate_type = 'Echo::Model::PlaytimeRegistry::Entities::PlaytimeReport' order by id asc limit 1;
         created_at         |                                        data
----------------------------+------------------------------------------------------------------------------------
 2017-08-30 09:54:29.865746 | {"ends_at": "2016-01-06T18:00:00+01:00", "starts_at": "2016-01-06T17:57:00+01:00"}
```

The string `2016-01-06T17:57:00+01:00` is passed in to the `TimeOfDay::load` during some part of the deviation detection. It occurred when we re-read a playtime report already read, and some deviations where ignored on this playtime report.

https://github.com/gramo-org/echo/issues/2898