### PR TITLE
Add raw fields to recording_drafts ES index

### DIFF
--- a/config/elasticsearch_indices/recording_drafts.json
+++ b/config/elasticsearch_indices/recording_drafts.json
@@ -8,7 +8,12 @@
               "type": "text"
             },
             "isrc": {
-              "type": "text"
+              "type": "text",
+              "fields": {
+                "raw": {
+                  "type": "keyword"
+                }
+              }
             }
           }
         },
@@ -144,7 +149,12 @@
               "type": "text"
             },
             "catalog_number": {
-              "type": "text"
+              "type": "text",
+              "fields": {
+                "raw": {
+                  "type": "keyword"
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
Add `raw` keyword fields to recording_drafts ES index. Needed for exact search implemented here: https://github.com/gramo-org/echo/pull/3359