### PR TITLE
Symbolize the return value of #update_by_query

### DIFF
--- a/lib/echo_common/services/elasticsearch/client.rb
+++ b/lib/echo_common/services/elasticsearch/client.rb
@@ -133,7 +133,7 @@ module EchoCommon
 
         # @see ::Elasticsearch::API::Actions#update_by_query
         def update_by_query(index:, wait_for_completion: true)
-          @client.update_by_query(
+          symbolize @client.update_by_query(
             index: with_prefix(index),
             wait_for_completion: wait_for_completion
           )


### PR DESCRIPTION
This method will return the ID of the created task, which we sometimes want.