### PR TITLE
Add retry on conflict option to elasticsearch update method

### DIFF
--- a/lib/echo_common/services/elasticsearch/client.rb
+++ b/lib/echo_common/services/elasticsearch/client.rb
@@ -53,9 +53,11 @@ module EchoCommon
           symbolize @client.index(index: with_prefix(index), type: type, id: id, body: body)
         end
 
-        def update(index:, type:, id:, body:)
+        # @param retry_on_conflict - by default Elastic sets this value to 0.
+        def update(index:, type:, id:, body:, retry_on_conflict: 0)
           symbolize @client.update(
             index: with_prefix(index), type: type, id: id,
+            retry_on_conflict: retry_on_conflict,
             body: body
           )
         end

--- a/spec/lib/services/elasticsearch/client_spec.rb
+++ b/spec/lib/services/elasticsearch/client_spec.rb
@@ -70,6 +70,7 @@ describe EchoCommon::Services::Elasticsearch::Client do
         index: "testing_foo",
         type: "bar",
         id: "baz",
+        retry_on_conflict: 0,
         body: "fizz"
       )
 


### PR DESCRIPTION
Allow update action to take option regarding updating partially via script.
In case of conflict - version mismatches, this option can be used to retry the update.

Especially useful when updating same documents by multiple clients.

See: https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html#_updates_and_conflicts