### PR TITLE
feat: added an elasticsearch restore wait-on-completion helper.

### DIFF
--- a/lib/echo_common/elasticsearch/restore_wait_on_completion.rb
+++ b/lib/echo_common/elasticsearch/restore_wait_on_completion.rb
@@ -1,0 +1,44 @@
+require 'echo_common/error'
+
+module EchoCommon
+  module Elasticsearch
+    # Restore a production snapshot takes longer than we are allowed to
+    # have an open connection with the normal 'wait_for_completion' option.
+    #
+    # In order to wait for a restore to complete we need to dig in to recovery
+    # status of our cluster.
+    #
+    # This class aids and exposes a user friendly API for waiting on the restore.
+    class RestoreWaitOnCompletion
+
+      # Create a new RestoreWaitOnCompletion instance
+      #
+      # @param      elasticsearch_client      Expecting ::Elasticsearch::Client.new
+      # @param      retries                   How many retries should we do?
+      # @param      wait_sec                  Seconds to wait between retries
+      def initialize(elasticsearch_client, retries: 200, wait_sec: 30)
+        @client = elasticsearch_client
+        @retries = retries
+        @wait_sec = wait_sec
+      end
+
+      def wait_for_completion
+        loop do
+          return if finished?
+
+          raise 'No retries left' if (@retries -= 1).zero?
+
+          sleep @wait_sec
+        end
+      end
+
+      private
+
+      def finished?
+        statuses = @client.cat.recovery h: ['st'], format: 'json'
+
+        statuses.all? { |s| s['st'] == 'done' }
+      end
+    end
+  end
+end

--- a/spec/lib/elasticsearch/restore_wait_on_completion_spec.rb
+++ b/spec/lib/elasticsearch/restore_wait_on_completion_spec.rb
@@ -1,0 +1,71 @@
+require 'echo_common/elasticsearch/restore_wait_on_completion'
+
+module EchoCommon
+  describe Elasticsearch::RestoreWaitOnCompletion do
+    class ElasticsearchCatApiMock
+      attr_accessor :responses, :call_counter, :call_args
+
+      def initialize
+        @call_counter = 0
+        @responses = []
+      end
+
+      def recovery(**args)
+        self.call_args = args
+
+        self.responses[(@call_counter += 1) - 1].tap do |response|
+          raise 'No responses left' if response.nil?
+        end
+      end
+    end
+
+    let(:api_mock) { ElasticsearchCatApiMock.new }
+    let(:client) { double cat: api_mock }
+
+    subject { described_class.new client, wait_sec: 0 }
+
+    describe '#wait_for_completion' do
+      it 'calls recovery with correct args' do
+        client.cat.responses = [
+          [{'st' => 'done'}]
+        ]
+
+        subject.wait_for_completion
+
+        expect(client.cat.call_args).to eq format: 'json', h: ['st']
+      end
+
+      it 'only calls recovery status once if all done' do
+        client.cat.responses = [
+          [{'st' => 'done'}]
+        ]
+
+        subject.wait_for_completion
+
+        expect(client.cat.call_counter).to eq 1
+      end
+
+      it 'calls recovery status twice we have to wait' do
+        client.cat.responses = [
+          [{'st' => 'index'}],
+          [{'st' => 'done'}],
+        ]
+
+        subject.wait_for_completion
+
+        expect(client.cat.call_counter).to eq 2
+      end
+
+      it 'raises exception if it has no retries left' do
+        subject = described_class.new client, wait_sec: 0, retries: 1
+
+        client.cat.responses = [
+          [{'st' => 'index'}],
+          [{'st' => 'index'}],
+        ]
+
+        expect { subject.wait_for_completion }.to raise_error 'No retries left'
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need to query the recovery api for the cluster in order to figure out
if we have completed and restored every index.

We found no way to figure this out via elasticsearch's task api, as it
only seems to be listed there if the restore request itself has
wait_for_completion=true. We need to wait longer than the gateway of
cloud.elastic.co allows in order to restore production indices, so this
code allows us to wait by polling.

Connected to https://github.com/gramo-org/echo/issues/4066