### PR TITLE
update jwt gem to 2.x version

### DIFF
--- a/echo_common.gemspec
+++ b/echo_common.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "hanami-model", "~> 0.6.1"
   spec.add_dependency "hanami-utils", "~> 0.8.0"
-  spec.add_dependency "jwt", "~> 1.5.2"
+  spec.add_dependency "jwt", "~> 2"
   spec.add_dependency "elasticsearch", "~> 5.0.3"
   spec.add_dependency "typhoeus", "~> 1.1.2"
   spec.add_dependency "database_cleaner", "~> 1.5.1"


### PR DESCRIPTION
Related to this PR: https://github.com/gramo-org/echo/pull/4270

New version of `nexmo` gem that we're using depends on `~> 2` version for `jwt`, which results into conflict in `echo_common` during `bundle install`.