### PR TITLE
Revert "Add release_year to release_drafts and recording_drafts"

### DIFF
--- a/config/elasticsearch_indices/recording_drafts.json.erb
+++ b/config/elasticsearch_indices/recording_drafts.json.erb
@@ -110,9 +110,6 @@
           "type": "date",
           "format": "strict_date_optional_time||epoch_millis"
         },
-        "release_year": {
-          "type": "integer"
-        },
         "recorded_in": {
           "type": "text"
         },

--- a/config/elasticsearch_indices/release_drafts.json.erb
+++ b/config/elasticsearch_indices/release_drafts.json.erb
@@ -72,9 +72,6 @@
           "type": "date",
           "format": "strict_date_optional_time||epoch_millis"
         },
-        "release_year": {
-          "type": "integer"
-        },
         "p_line": {
           "type": "text"
         },


### PR DESCRIPTION
Reverts gramo-org/echo_common#71
We decided not to do anything with release year for drafts for now ([more info in comment and below here](https://github.com/gramo-org/min-side/issues/782#issuecomment-493038559)).