### PR TITLE
Add new raw fields to release_drafts mapping

### DIFF
--- a/config/elasticsearch_indices/recording_drafts.json.erb
+++ b/config/elasticsearch_indices/recording_drafts.json.erb
@@ -102,6 +102,9 @@
         "performer_note": {
           "type": "text"
         },
+        "performances": {
+          "type": "nested"
+        },
         "recording_date": {
           "type": "date",
           "format": "strict_date_optional_time||epoch_millis"

--- a/config/elasticsearch_indices/release_drafts.json.erb
+++ b/config/elasticsearch_indices/release_drafts.json.erb
@@ -52,6 +52,9 @@
         "label_name": {
           "type": "text",
           "fields":{
+            "raw": {
+              "type": "keyword"
+            },
             "lowercase_token": {
               "type": "keyword"
             }
@@ -79,7 +82,12 @@
           "type": "text"
         },
         "catalog_number": {
-          "type": "text"
+          "type": "text",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
         },
         "source": {
           "type": "text"


### PR DESCRIPTION
- Add new raw fields to label_name and catalog_number in release_drafts mapping to allow sorting by them in min-side global search

Connected to https://github.com/gramo-org/min-side/issues/783
Echo PR: https://github.com/gramo-org/echo/pull/4336
