### PR TITLE
fix: IPAddr::load works given an IPAddr object

### DIFF
--- a/lib/echo_common/hanami/models/coercer/ip_addr.rb
+++ b/lib/echo_common/hanami/models/coercer/ip_addr.rb
@@ -7,6 +7,7 @@ module EchoCommon
       module Coercer
         class IPAddr < ::Hanami::Model::Coercer
           def self.load(value)
+            return value if value.is_a? ::IPAddr
             ::IPAddr.new value unless value.nil?
           end
 

--- a/spec/lib/hanami/models/coercer/ip_addr_spec.rb
+++ b/spec/lib/hanami/models/coercer/ip_addr_spec.rb
@@ -3,10 +3,15 @@ require 'echo_common/hanami/models/coercer/ip_addr'
 
 describe EchoCommon::Hanami::Models::Coercer::IPAddr do
   let(:ip) { "127.0.0.1" }
+  let(:ip_as_object) { ::IPAddr.new ip }
 
   describe ".load" do
     it "creates an IPAddr representing the value" do
       expect(described_class.load(ip)).to eq ::IPAddr.new ip
+    end
+
+    it "returns given IPAddr object if value is a IPAddr" do
+      expect(described_class.load(ip_as_object)).to eq ip_as_object
     end
 
     it "returns nil if value is nil" do


### PR DESCRIPTION
Previously it had to be a string or nil, but as sequel_pg now returns
IPAddr objects when a row is read from the DB we must support this too.

Relates to https://github.com/gramo-org/echo/issues/4442