### PR TITLE
Feat: Add unify_apostrophes_analyzer to recording/release drafts indices

### DIFF
--- a/config/elasticsearch_indices/recording_drafts.json.erb
+++ b/config/elasticsearch_indices/recording_drafts.json.erb
@@ -10,11 +10,27 @@
             "asciifolding"
            ]
         }
+      },
+      "analyzer": {
+        "unify_apostrophes_analyzer": {
+          "tokenizer": "standard",
+          "char_filter": ["unify_apostrophes"]
+        }
+      },
+      "char_filter": {
+        "unify_apostrophes": {
+          "type": "pattern_replace",
+          "pattern": "[`´]",
+          "replacement": "'"
+        }
       }
     }
   },
   "mappings": {
     "recording_draft": {
+      "_all": {
+        "analyzer": "unify_apostrophes_analyzer"
+      },
       "properties": {
         "alternative_isrcs": {
           "properties": {
@@ -58,6 +74,7 @@
         },
         "label_name": {
           "type": "text",
+          "analyzer": "unify_apostrophes_analyzer",
           "fields": {
             "raw": {
               "type": "keyword",
@@ -78,6 +95,7 @@
         },
         "main_artist": {
           "type": "text",
+          "analyzer": "unify_apostrophes_analyzer",
           "fields": {
             "raw": {
               "type": "keyword",
@@ -135,6 +153,7 @@
         },
         "title": {
           "type": "text",
+          "analyzer": "unify_apostrophes_analyzer",
           "fields": {
             "raw": {
               "type": "keyword",

--- a/config/elasticsearch_indices/recording_drafts.json.erb
+++ b/config/elasticsearch_indices/recording_drafts.json.erb
@@ -14,6 +14,7 @@
       "analyzer": {
         "unify_apostrophes_analyzer": {
           "tokenizer": "standard",
+          "filter": ["lowercase"],
           "char_filter": ["unify_apostrophes"]
         }
       },

--- a/config/elasticsearch_indices/release_drafts.json.erb
+++ b/config/elasticsearch_indices/release_drafts.json.erb
@@ -12,6 +12,7 @@
         },
         "unify_apostrophes_analyzer": {
           "tokenizer": "standard",
+          "filter": ["lowercase"],
           "char_filter": ["unify_apostrophes"]
         }
       },

--- a/config/elasticsearch_indices/release_drafts.json.erb
+++ b/config/elasticsearch_indices/release_drafts.json.erb
@@ -9,6 +9,10 @@
           "tokenizer": "keyword",
           "filter": ["lowercase"],
           "type": "custom"
+        },
+        "unify_apostrophes_analyzer": {
+          "tokenizer": "standard",
+          "char_filter": ["unify_apostrophes"]
         }
       },
       "normalizer": {
@@ -20,11 +24,21 @@
             "asciifolding"
            ]
         }
+      },
+      "char_filter": {
+        "unify_apostrophes": {
+          "type": "pattern_replace",
+          "pattern": "[`´]",
+          "replacement": "'"
+        }
       }
     }
   },
   "mappings": {
     "release_draft": {
+      "_all": {
+        "analyzer": "unify_apostrophes_analyzer"
+      },
       "properties": {
         "id": {
           "type": "text"
@@ -34,6 +48,7 @@
         },
         "title": {
           "type": "text",
+          "analyzer": "unify_apostrophes_analyzer",
           "fields": {
             "raw": {
               "type": "keyword",
@@ -62,6 +77,7 @@
         },
         "label_name": {
           "type": "text",
+          "analyzer": "unify_apostrophes_analyzer",
           "fields":{
             "raw": {
               "type": "keyword",
@@ -74,6 +90,7 @@
         },        
         "main_artist": {
           "type": "text",
+          "analyzer": "unify_apostrophes_analyzer",
           "fields": {
             "raw": {
               "type": "keyword",


### PR DESCRIPTION
Add unify_apostrophes_analyzer to recording/release drafts indices

Echo: https://github.com/gramo-org/echo/pull/4676
Related issue: gramo-org/min-side#222