### PR TITLE
feat(elastic): suppress shards failures when searching

### DIFF
--- a/lib/echo_common/services/elasticsearch/client.rb
+++ b/lib/echo_common/services/elasticsearch/client.rb
@@ -77,9 +77,12 @@ module EchoCommon
           )
         end
 
-        def search(index:, **options)
+        def search(index:, suppress_shards_failures: false, **options)
           response = @client.search(index: with_prefix(index, allow_multi_index: true), **options)
-          raise IndexShardsError, response['_shards']['failures'] if response && response['_shards']['failures']
+
+          if !suppress_shards_failures && response && response['_shards']['failures']
+            raise IndexShardsError, response['_shards']['failures']
+          end
 
           symbolize(response)[:hits]
         end

--- a/spec/lib/services/elasticsearch/client_spec.rb
+++ b/spec/lib/services/elasticsearch/client_spec.rb
@@ -156,8 +156,9 @@ describe EchoCommon::Services::Elasticsearch::Client do
       client.search(index: "foo*,-foo5", type: nil, body: "fizz")
     end
 
-    it 'raising the error when shards failures are found' do
-      allow(elasticsearch_client).to receive(:search).with(
+    describe 'IndexShardsError' do
+      before do
+        allow(elasticsearch_client).to receive(:search).with(
         index: 'testing_some_alias',
         type: nil,
         body: 'fizz'
@@ -170,9 +171,17 @@ describe EchoCommon::Services::Elasticsearch::Client do
           }
         }
       )
+      end
 
-      expect { client.search(index: "some_alias", type: nil, body: "fizz") }
-        .to raise_error(an_instance_of(EchoCommon::Services::Elasticsearch::Client::IndexShardsError))
+      it 'raising the error when shards failures are found' do
+        expect { client.search(index: "some_alias", type: nil, body: "fizz") }
+          .to raise_error EchoCommon::Services::Elasticsearch::Client::IndexShardsError
+      end
+
+      it 'can suppress shards error' do
+        expect { client.search(suppress_shards_failures: true, index: "some_alias", type: nil, body: "fizz") }
+          .to_not raise_error
+      end
     end
   end
 


### PR DESCRIPTION
Our reason for requiring this is that we have repositories in Echo,
which works towards recordings index to find recordings with given
producer owner ids.

The thing which complicates it is that this recording repository
actually works towards a @discography alias which spans over recordings
and discography_drafts index.

The draft index does not have the same fields as the recording in
regards to for instance ownerships.

So when we introduced the IndexShardsError error it made this code in
Echo fail.

The IndexShardsError was introduced back in October 2019, but didn't
make its way in to Echo before now :-(

Connected to https://github.com/gramo-org/echo/pull/4936#issuecomment-572459485
Connected to https://github.com/gramo-org/echo/issues/4933
Related to https://github.com/gramo-org/echo_common/pull/91
