### PR TITLE
Elasticsearch: Don't delete IDs from documents when indexing

### DIFF
--- a/lib/echo_common/services/elasticsearch/operations/crud.rb
+++ b/lib/echo_common/services/elasticsearch/operations/crud.rb
@@ -81,9 +81,9 @@ module EchoCommon
           #     "_version" : 1,
           #     "created" : true
           #   }
-          def index(id: nil, **doc)
+          def index(doc)
             @client.index(
-              index: @index, type: @type, id: id,
+              index: @index, type: @type, id: doc[:id],
               body: doc
             )
           end

--- a/spec/lib/services/elasticsearch_spec.rb
+++ b/spec/lib/services/elasticsearch_spec.rb
@@ -27,8 +27,8 @@ describe EchoCommon::Services::Elasticsearch do
       subject.index id: 'my-id', some: :data
     end
 
-    it 'does not pass id within body / document data to be indexed' do
-      expect(client).to receive(:index).with(hash_including(body: { some: :data }))
+    it 'does pass id within body / document data to be indexed' do
+      expect(client).to receive(:index).with(hash_including(body: { id: 'my-id', some: :data }))
       subject.index id: 'my-id', some: :data
     end
 


### PR DESCRIPTION
This reverts the change that got introduced to fix https://github.com/gramo-org/echo/issues/4933. Gramo needs to be able to search for IDs, so we will instead update the mapping of the index (by reindexing) to solve this problem.