### PR TITLE
fix: Ensure the DB is still "cleaned" even when transactions are not used

### DIFF
--- a/lib/echo_common/rspec/helpers/db_clean_helper.rb
+++ b/lib/echo_common/rspec/helpers/db_clean_helper.rb
@@ -10,12 +10,13 @@ module EchoCommon
         def self.included(base)
           base.class_eval do
             around(:each) do |example|
-              if example.metadata[:omit_database_transaction]
+              DatabaseCleaner.strategy = if example.metadata[:omit_database_transaction]
+                                           :truncation
+                                         else
+                                           :transaction
+                                         end
+              DatabaseCleaner.cleaning do
                 example.run
-              else
-                DatabaseCleaner.cleaning do
-                  example.run
-                end
               end
             end
           end


### PR DESCRIPTION
In some tests, we might ensure that a transaction has been rolled back (e.g. if
an error occurred). Since currently we do not support transactions within other
transactions, those tests use the `omit_database_transaction` flag which means
the test does not get wrapped in a transaction. The problem is that these tests
now leave data lying around after running.

Our original plan to solve this was to find a way to still rollback in the app
despite already running in a transaction. However Sequel does not support naming
a transaction from what I can tell, and anyway there is no way to pass args to
the transaction via the `DatabaseCleaner` gem. Going through some issues I found
this issue:
  https://github.com/DatabaseCleaner/database_cleaner/issues/652

Basically this person wants to read data from the DB in another app, but in only
some tests. He took the approach of switching "strategy" to accomplish it. I am
basically stealing the same idea since it seems to work and was quite trivial.
The big downside is that those tests will probably take longer to run, luckily
only 5 tests use this flag currently in echo, so this should not be too big of a
problem.