### PR TITLE
Add "external_foreign_key" to recordings

### DIFF
--- a/config/elasticsearch_indices/recording_drafts.json.erb
+++ b/config/elasticsearch_indices/recording_drafts.json.erb
@@ -62,7 +62,10 @@
           "type": "float"
         },
         "id": {
-          "type": "text"
+          "type": "keyword"
+        },
+        "external_foreign_key": {
+          "type": "keyword"
         },
         "isrc": {
           "type": "text",

--- a/config/elasticsearch_indices/release_drafts.json.erb
+++ b/config/elasticsearch_indices/release_drafts.json.erb
@@ -42,10 +42,10 @@
       },
       "properties": {
         "id": {
-          "type": "text"
+          "type": "keyword"
         },
         "external_foreign_key": {
-          "type": "text"
+          "type": "keyword"
         },
         "title": {
           "type": "text",
@@ -88,7 +88,7 @@
               "type": "keyword"
             }
           }
-        },        
+        },
         "main_artist": {
           "type": "text",
           "analyzer": "unify_apostrophes_analyzer",

--- a/lib/echo_common/recording_draft.rb
+++ b/lib/echo_common/recording_draft.rb
@@ -1,6 +1,7 @@
 # coding: utf-8
 module EchoCommon
   class RecordingDraft < EchoCommon::Entity
+    attributes :external_foreign_key
     attributes :title, :isrc, :duration_in_seconds
     attributes :recording_date, :release_date, :performer_note, :label_name,
                :p_line, :recorded_in


### PR DESCRIPTION
Currently we rely on local ids in echo to store the connection between an echo
recording and the draft it is based on. The problem is that we "retire" entries
when new data about a release/recording comes in, and we would like to "clean"
that old data without breaking the connection to echo.

The plan is to actually replace the ID in ES with the external foreign key, but
since release already had this field I figured I may as well add it anyway, we
can always remove it later. I also "fixed" the types we use to be `keyword`.

Connected to https://github.com/gramo-org/echo/issues/5434