### PR TITLE
Remove the query alias functionality

### DIFF
--- a/lib/echo_common/rspec/helpers/elasticsearch_helper.rb
+++ b/lib/echo_common/rspec/helpers/elasticsearch_helper.rb
@@ -137,15 +137,11 @@ module EchoCommon
             end
           end
 
-          # placeholder hook, overridden in echo
-          def setup_query_alias; end
-
           def setup_and_refresh_indices
             EchoCommon::Services::Elasticsearch.delete_all_indices
             EchoCommon::Services::Elasticsearch.client.refresh_indices
 
             EchoCommon::Services::Elasticsearch.create_all_indices
-            setup_query_alias
             EchoCommon::Services::Elasticsearch.client.refresh_indices
           end
 
@@ -157,7 +153,6 @@ module EchoCommon
               EchoCommon::Services::Elasticsearch.delete_index(index)
               EchoCommon::Services::Elasticsearch.create_index(index)
             end
-            setup_query_alias
             EchoCommon::Services::Elasticsearch.client.refresh_indices
           end
         end

--- a/lib/echo_common/services/elasticsearch.rb
+++ b/lib/echo_common/services/elasticsearch.rb
@@ -13,11 +13,10 @@ module EchoCommon
       def initialize(
         index: nil,
         type: nil,
-        client: self.class.client,
-        query_alias: nil
+        client: self.class.client
       )
         @index = index
-        @query_index = query_alias || index
+        @query_index = index
         @type = type
         @client = client
       end


### PR DESCRIPTION
It was pretty broken, and we don't use it anymore.