### PR TITLE
Add `delete_by_query` elasticsearch method

### DIFF
--- a/lib/echo_common/services/elasticsearch/client.rb
+++ b/lib/echo_common/services/elasticsearch/client.rb
@@ -158,6 +158,13 @@ module EchoCommon
           )
         end
 
+        def delete_by_query(index:, **options)
+          symbolize @client.delete_by_query(
+            index: with_prefix(index),
+            **options
+          )
+        end
+
         def list_tasks(**options)
           symbolize @client.tasks.list(**options)
         end


### PR DESCRIPTION
I am adding a new elasticsearch projection for foreign remuneration snapshot
groups in echo. One requirement is to delete all groups belonging to a specific
snapshot when that snapshot is deleted, or fails to build.

Rather than loading all the groups and looping each one to delete them, it is
more efficient to have the deletion done on the elasticsearch side, since this
will reduce the chance of race conditions and require less network overhead.

Connected to https://github.com/gramo-org/echo/issues/5740
