### PR TITLE
fix: Allow mapping files to share the same ending

### DIFF
--- a/lib/echo_common/services/elasticsearch/client.rb
+++ b/lib/echo_common/services/elasticsearch/client.rb
@@ -105,7 +105,7 @@ module EchoCommon
 
         def create_index(index)
           json_file_name = mapping_file_name index
-          create_all_indices(filter: -> (f) { f.end_with? json_file_name })
+          create_all_indices(filter: -> (f) { f.split('/').last == json_file_name })
         end
 
         def create_all_indices(filter: -> (f) { true })


### PR DESCRIPTION
I created a new mapping file: foreign_remuneration_snapshot_groups.json.erb

Unfortunately, if the the `groups` index needed to be created, it would find my
mapping file too since it also ends in `groups.json.erb`. Lets just say this was
not fun to debug.

Connected to https://github.com/gramo-org/echo/issues/5740