### PR TITLE
Use a set in the `Entity::Relation::Many` class for much better performance

### DIFF
--- a/lib/echo_common/entity/relation/many.rb
+++ b/lib/echo_common/entity/relation/many.rb
@@ -18,10 +18,9 @@ module EchoCommon
         def_delegators :@collection,
           :delete,
           :each, :each_with_index, :map,
-          :length, :first, :last, :[],
+          :length, :first, :last,
           :any?, :empty?, :include?,
-          :==, :equal?, :eql?, :eq?, :hash
-
+          :==, :equal?, :eql?, :hash
 
         class AlreadyAddedError < EchoCommon::Error
           attr_reader :object, :relation
@@ -34,14 +33,14 @@ module EchoCommon
           end
         end
 
-        def initialize(owner, collection = [])
+        def initialize(owner, collection = Set.new)
           @owner = owner
           @collection = collection
         end
 
         def push(object)
           raise AlreadyAddedError.new(object, self) if @collection.include? object
-          @collection.push object
+          @collection.add object
         end
         alias_method :<<, :push
 
@@ -51,6 +50,9 @@ module EchoCommon
         end
         alias_method :to_s, :inspect
 
+        def [](*args)
+          @collection.to_a[*args]
+        end
 
         private
 

--- a/spec/lib/entity/relation/many_spec.rb
+++ b/spec/lib/entity/relation/many_spec.rb
@@ -19,7 +19,7 @@ module EchoCommon
       subject << obj
 
       expect(subject).to_not be_empty
-      expect(subject).to eq [obj]
+      expect(subject.first).to eq obj
     end
 
     it "raises error when adding duplicates" do
@@ -29,6 +29,13 @@ module EchoCommon
       expect {
         subject << obj
       }.to raise_error Entity::Relation::Many::AlreadyAddedError
+    end
+
+    it "can fetch object by index" do
+      obj = "obj"
+      subject << obj
+
+      expect(subject[0]).to eq obj
     end
   end
 end


### PR DESCRIPTION
When we have large collections, using `include?` requires checking the whole
array every time a new item is added, which kill performance. Using a `Set`
means it takes a fraction of the time.

Also, `eq?` is not a method on arrays, so I have removed it.

Connected to https://github.com/gramo-org/echo/issues/6287