### PR TITLE
Ensure we return `self` from `push` method

### DIFF
--- a/lib/echo_common/entity/relation/many.rb
+++ b/lib/echo_common/entity/relation/many.rb
@@ -41,9 +41,10 @@ module EchoCommon
         def push(object)
           raise AlreadyAddedError.new(object, self) if @collection.include? object
           @collection.add object
+
+          self
         end
         alias_method :<<, :push
-
 
         def inspect
           "<#{self.class.name} owner: #{@owner.class.name}, length: #{length}>"

--- a/spec/lib/entity/relation/many_spec.rb
+++ b/spec/lib/entity/relation/many_spec.rb
@@ -17,8 +17,10 @@ module EchoCommon
 
     it "can add objects" do
       obj = "obj"
-      subject << obj
+      result = subject << obj
 
+      expect(result.class).to eq subject.class
+      expect(result.object_id).to eq subject.object_id
       expect(subject).to_not be_empty
       expect(subject.first).to eq obj
     end


### PR DESCRIPTION
In echo, one unit test failed, because two Programs shared the same ID. Turns
out that the `AlreadyAddedError` error was not raised in the `before` block,
because it was doing the following:

```ruby
subject << program_music << program_news << program_unicode
```

Since `<<` was returning `@collection`, the second `<<` was using the `push`
method on the `Set` directly.

For some reason, the following does not work:

```ruby
expect(subject).to equal subject
```

Which is why I am checking `object_id` and `class` directly